### PR TITLE
cpm iops benchmark

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -85,11 +85,11 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            **Linux kernel**: 3.10 or higher.
+            **Linux kernel:** 3.10 or higher
+            **macOS:** 10.11 or higher
+            **Windows:** Windows 10 64-bit or higher
 
-            **macOS**: 10.11 or higher.
-
-            **Windows**: Windows 10 64-bit or higher. You must also configure Docker to run Linux containers in order for CPMs to work on Windows systems.
+            _You must also configure Docker to run Linux containers in order for CPMs to work on Windows systems._
           </td>
         </tr>
 
@@ -115,11 +115,38 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
 
         <tr>
           <td>
-            Disk space
+            Disk size
           </td>
 
           <td>
-            A minimum of 10 GB per host
+            A minimum of 50 GiB per host
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Disk performance (IOPS)
+          </td>
+
+          <td>
+            **Ping:** Negligible
+            **Scripted API:** 7
+            **Simple Browser:** 27
+            **Scripted Browser:** 28
+
+            Measured by monitoring write throughput for [https://newrelic.com](https://newrelic.com) on an AWS EC2 m5.xlarge instance with: AL2, gp2 storage class, 50 GiB root volume, a default [Docker CPM install](#docker-update), and 1 monitor at a time set to 1-minute frequency. Efficiency gains are expected with multiple monitors running. These values may be higher or lower than your own depending on many factors.
+
+            _Baseline for Docker CPM is 0.5 IOPS with no monitor jobs running._
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Disk file system
+          </td>
+
+          <td>
+            NFSv4.1 or higher (if using NFS)
           </td>
         </tr>
 
@@ -174,11 +201,9 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            **Linux kernel**: 3.10 or higher
-
-            **macOS**: 10.11 or higher
-
-            **Windows**: Windows 10 64-bit or higher
+            **Linux kernel:** 3.10 or higher
+            **macOS:** 10.11 or higher
+            **Windows:** Windows 10 64-bit or higher
           </td>
         </tr>
 
@@ -198,9 +223,8 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            **CPU (vCPU/Core)**: 0.5 up to 0.75
-
-            **Memory**: 800 Mi up to 1.6 Gi
+            **CPU (vCPU/Core):** 0.5 up to 0.75
+            **Memory:** 0.8Gi up to 1.6Gi
 
             Resources allocated to a Minion pod are user configurable.
           </td>
@@ -212,31 +236,56 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            **CPU (vCPU/Core)**: 0.5 up to 1
+            **CPU (vCPU/Core):** 0.5 up to 1
+            **Memory:** 1.25Gi up to 3Gi
 
-            **Memory**: 1.25 Gi up to 3 Gi
+            * For a scripted API check, 1.25Gi will be requested with a limit of 2.5Gi.
+            * For a simple browser or scripted browser check, 2Gi will be requested with a limit of 3Gi.
 
-            * For a scripted API check, 1.25 Gi will be requested with a limit of 2.5 Gi.
-
-            * For a simple browser or scripted browser check, 2 Gi will be requested with a limit of 3 Gi.
-
-              Additional considerations:
+            Additional considerations:
 
             * Resources allocated to a runner pod are not user configurable.
-
             * The maximum limit-request resource ratio for both CPU and memory is 2.
           </td>
         </tr>
 
         <tr>
           <td>
-            Disk space
+            Disk size
           </td>
 
           <td>
-            Persistent volume (PV) of at least 10 Gi in size
+            **Root volume:** A minimum of 50 GiB (node + PV)
+            **Persistent volume (PV):** A minimum of 20 GiB
 
-            Note that if a `ReadWriteOnce` (RWO) PV is provided to the minion, an implicit node affinity will be established to ensure the minion and the runner containers are scheduled on the same node. This is required to allow the minion and the associated runners access to the PV, as an RWO PV can be accessed only by a single node in the cluster.
+            If a `ReadWriteOnce` (RWO) PV is provided to the minion, an implicit node affinity will be established to ensure the minion and the runner containers are scheduled on the same node. This is required to allow the minion and the associated runners access to the PV, as an RWO PV can be accessed only by a single node in the cluster.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Disk performance (IOPS)
+          </td>
+
+          <td>
+            **Ping:** Negligible
+            **Scripted API:** 11
+            **Simple Browser:** 33
+            **Scripted Browser:** 31
+
+            Measured by monitoring write throughput for [https://newrelic.com](https://newrelic.com) on an AWS EKS 1.21 cluster backed by one EC2 m5.xlarge node running with: gp2 storage class, 50 GiB root volume, 20 GiB PV/PVC with RWO access mode, a default [Kubernetes CPM install](#kubernetes-install) via Helm, and 1 monitor at a time set to 1-minute frequency. Efficiency gains are expected with multiple monitors running. These values may be higher or lower than your own depending on many factors.
+
+            _Baseline for Kubernetes CPM is 3.0 IOPS with no monitor jobs running._
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Disk file system
+          </td>
+
+          <td>
+            NFSv4.1 or higher (if using NFS)
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/monitor-private-locations.mdx
@@ -25,7 +25,7 @@ Before following the instructions in this guide, ensure you have:
 * A [synthetic private location](/docs/synthetics/new-relic-synthetics/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations)
 * At least one [private minion](/docs/synthetics/new-relic-synthetics/private-locations/install-containerized-private-minions-cpms#install-update) installed at that location
 * Checks scheduled to run at that location
-* An [alert policy](/docs/alerts/new-relic-alerts/configuring-alert-policies) for the private location, with a configured [notification channel](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts#slack) to notify your team when a violation occurs
+* An [alert policy](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow/) for the private location, with a configured [notification channel](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts/) to notify your team when a violation occurs
 
 The following Private Minion dashboard example JSON can be imported to your account using:
 


### PR DESCRIPTION
- Add IOPS benchmark values to CPM requirements. The disk can be a source of performance issues for the CPM, especially for write operations. These benchmark values are designed to provide some awareness to disk performance.